### PR TITLE
Reorganise

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,7 @@ FLoops = "cc61a311-1640-44b5-9fba-1b764f453329"
 MicroCollections = "128add7d-3638-4c79-886c-908ea0c25c34"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
 BangBang = "0.3.29"

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ The main functionality of the package is the `analyze` and `analyze_from_registr
 julia> analyze_from_registry(joinpath(general_registry(), "F", "Flux"))
 Package Flux:
   * repo: https://github.com/FluxML/Flux.jl.git
+  * uuid: 587475ba-b771-5e3f-ad9e-33799f191a9c
   * is reachable: true
   * has documentation: true
   * has tests: true
@@ -101,6 +102,7 @@ julia> using AnalyzeRegistry
 julia> analyze(pkgdir(AnalyzeRegistry))
 Package AnalyzeRegistry:
   * repo: 
+  * uuid: e713c705-17e4-4cec-abe0-95bf5bf3e10c
   * is reachable: true
   * has documentation: false
   * has tests: true

--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@ Pkg.add("https://github.com/giordano/AnalyzeRegistry.jl")
 
 ## Usage
 
-The main functionality of the package is the `analyze` function:
+The main functionality of the package is the `analyze` and `analyze_from_registry` functions:
 
 ```julia
-julia> analyze(joinpath(general_registry(), "F", "Flux"))
+julia> analyze_from_registry(joinpath(general_registry(), "F", "Flux"))
 Package Flux:
   * repo: https://github.com/FluxML/Flux.jl.git
   * is reachable: true
@@ -51,6 +51,7 @@ The returned value is the struct `Package`, which has the following fields:
 ```julia
 struct Package
     name::String # name of the package
+    uuid::UUID # uuid of the package
     repo::String # URL of the repository
     reachable::Bool # can the repository be cloned?
     docs::Bool # does it have documentation?
@@ -87,7 +88,25 @@ julia> find_packages(general_registry())
  "/home/user/.julia/registries/General/S/Strapping"
  [...]
 ```
-Do not abuse of this function!
+Do not abuse this function!
+
+You use `analyze_from_registry!(root, joinpath(general_registry(), "F", "Flux"))` to clone
+the package to a particular directory `root` which is not cleaned up afterwards.
+
+You can also analyze the source code of a package via `analyze`, for example
+
+```julia
+julia> using AnalyzeRegistry
+
+julia> analyze(pkgdir(AnalyzeRegistry))
+Package AnalyzeRegistry:
+  * repo: 
+  * is reachable: true
+  * has documentation: false
+  * has tests: true
+  * has continuous integration: true
+    * GitHub Actions
+```
 
 ## License
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using Test
+using Test, UUIDs
 
 using AnalyzeRegistry
 
@@ -8,19 +8,37 @@ using AnalyzeRegistry
     @test all(isdir, find_packages())
     # Test some properties of the `Measurements` package.  NOTE: they may change
     # in the future!
-    measurements = analyze(joinpath(general, "M", "Measurements"))
+    measurements = analyze_from_registry(joinpath(general, "M", "Measurements"))
+    @test measurements.uuid == UUID("eff96d63-e80a-5855-80a2-b1b0885c5ab7")
     @test measurements.reachable
     @test measurements.docs
     @test measurements.runtests
     @test !measurements.buildkite
     # Test results of a couple of packages.  Same caveat as above
     packages = [joinpath(general, p...) for p in (("C", "Cuba"), ("P", "PolynomialRoots"))]
-    results = analyze(packages)
+    results = analyze_from_registry(packages)
     cuba, polyroots = results
     @test length(filter(p -> p.reachable, results)) == 2
     @test length(filter(p -> p.runtests, results)) == 2
     @test cuba.drone
     @test !polyroots.docs # Documentation is in the README!
     # We can also use broadcasting!
-    @test Set(results) == Set(analyze.(packages))
+    @test Set(results) == Set(analyze_from_registry.(packages))
+
+    # check `analyze_from_registry!` directly
+    mktempdir() do root
+        measurements2 = analyze_from_registry!(root, joinpath(general, "M", "Measurements"))
+        @test measurements == measurements2
+        @test isdir(joinpath(root, "eff96d63-e80a-5855-80a2-b1b0885c5ab7")) # not cleaned up yet
+    end
+end
+
+@testset "`analyze`" begin
+    pkg = analyze(pkgdir(AnalyzeRegistry))
+    @test pkg.repo == "" # can't find repo from source code
+    @test pkg.uuid == UUID("e713c705-17e4-4cec-abe0-95bf5bf3e10c")
+    @test pkg.reachable == true # default
+    @test pkg.docs == false
+    @test pkg.runtests == true # here we are!
+    @test pkg.github_actions == true
 end


### PR DESCRIPTION
Hi @giordano, I've tried to address #5 here. I decided to clone to a directory named by the UUID instead of the package name, to allow one to reuse the same `root` for multiple registries which could possibly have packages with the same names (but different UUIDs). I also added a `uuid` field to the package so it was easier to find where it would be (i.e. if you do `pkg = analyze_from_registry!(root, ...)` then `joinpath(root, string(pkg.uuid))` gives you the folder it got cloned to).

I also changed the `analyze` function to be the one using the source code directory, and what used to be called analyze is now `analyze_from_registry`, which I thought might be clearer. Something kind of fun is that you can use `analyze` with `pkgdir` so that you don't need to clone for packages you've already loaded into your Julia session.