### PR TITLE
only parse Project.toml when necessary, and parse more robustly

### DIFF
--- a/test/baduuid.toml
+++ b/test/baduuid.toml
@@ -1,0 +1,2 @@
+name = "AnalyzeRegistry"
+uuid = "hello"

--- a/test/missingquote.toml
+++ b/test/missingquote.toml
@@ -1,0 +1,2 @@
+name = "AnalyzeRegistry"
+uuid = "e713c705-17e4-4cec-abe0-95bf5bf3e10c

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using Test, UUIDs
 
 using AnalyzeRegistry
+using AnalyzeRegistry: parse_name_uuid
 
 @testset "AnalyzeRegistry" begin
     general = general_registry()
@@ -41,4 +42,20 @@ end
     @test pkg.docs == false
     @test pkg.runtests == true # here we are!
     @test pkg.github_actions == true
+end
+
+@testset "`parse_name_uuid`" begin
+    bad_project = (; name = "Invalid Project.toml", uuid = UUID(UInt128(0)))
+    # malformatted TOML file
+    @test parse_name_uuid("missingquote.toml") == bad_project
+
+    # bad UUID
+    @test parse_name_uuid("baduuid.toml") == bad_project
+
+    # non-existent file
+    @test parse_name_uuid("rstratarstra") == bad_project
+
+    # proper Project.toml
+    this_project = (; name = "AnalyzeRegistry", uuid = UUID("e713c705-17e4-4cec-abe0-95bf5bf3e10c"))
+    @test parse_name_uuid(joinpath(@__DIR__, "..", "Project.toml")) == this_project
 end


### PR DESCRIPTION
In #6, I changed from using the name and UUID from the registry to instead parsing it from the Project.toml. I did this just because we need to parse from the Project for `analyze` (where we don't have registry information) and it was easier to do it the same way in either case. I realized however that this wasn't a good idea, because we don't know that the master branch of every package has a valid Project.toml (the registered releases do, but anything could have happened since then).

So instead, here I only parse the Project.toml when needed, i.e. when you don't supply the name and UUID as keyword arguments to `analyze`. I also made the project parsing much more robust, so it shouldn't throw even if the Project doesn't exist or is invalid.