### PR TITLE
tweak find packages API

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ analysis with multiple threads.
 You can use the function `find_packages` to find all packages in a given
 registry:
 ```julia
-julia> find_packages(general_registry())
+julia> find_packages(; registry=general_registry())
 4312-element Vector{String}:
  "/home/user/.julia/registries/General/C/CitableImage"
  "/home/user/.julia/registries/General/T/Trixi2Img"

--- a/src/AnalyzeRegistry.jl
+++ b/src/AnalyzeRegistry.jl
@@ -164,7 +164,7 @@ function find_packages(; registry = general_registry())
     # Get the directories of all packages.  Filter out JLL packages: they are
     # automatically generated and we know that they don't have testing nor
     # documentation.
-    return [joinpath(registry, p["path"]) for (_, p) in packages if !endswith(p["name"], "_jll")]
+    return [joinpath(registry, splitpath(p["path"])...) for (_, p) in packages if !endswith(p["name"], "_jll")]
 end
 
 """

--- a/src/AnalyzeRegistry.jl
+++ b/src/AnalyzeRegistry.jl
@@ -125,21 +125,46 @@ Guess the path of the General registry.
 general_registry() =
     first([joinpath(d, "registries", "General") for d in Pkg.depots() if isfile(joinpath(d, "registries", "General", "Registry.toml"))])
 
-"""
-    find_packages(dir = general_registry()) -> Vector{String}
 
-Find all packages in the given registry, the General registry by default.
-Return a vector with the paths to the directories of each package in the
-registry.
 """
-function find_packages(dir = general_registry())
+    find_packages(; registry = general_registry()) -> Vector{String}
+    find_packages(names::AbstractString...; registry = general_registry()) -> Vector{String}
+    find_packages(names; registry = general_registry()) -> Vector{String}
+
+Find all packages in the given registry (specified by the `registry` keyword argument),
+the General registry by default. Return a vector with the paths to the directories
+of each package in the registry.
+
+Pass a list of package `names` as the first argument to return the paths corresponding to those packages,
+or individual package names as separate arguments.
+"""
+find_packages
+
+find_packages(names::AbstractString...; registry = general_registry()) =  find_packages(names; registry=registry)
+
+function find_packages(names; registry = general_registry())
+    if names !== nothing
+        paths = String[]
+        for name in names
+            path = joinpath(registry, string(uppercase(first(name))), name)
+            if isdir(path)
+               push!(paths, path) 
+            else
+                @error("Could not find package in registry!", name, path)
+            end
+        end
+        return paths
+    end
+end
+
+function find_packages(; registry = general_registry())
     # Get the list of packages in the registry by parsing the `Registry.toml`
     # file in the given directory.
-    packages = TOML.parsefile(joinpath(dir, "Registry.toml"))["packages"]
+    packages = TOML.parsefile(joinpath(registry, "Registry.toml"))["packages"]
     # Get the directories of all packages.  Filter out JLL packages: they are
     # automatically generated and we know that they don't have testing nor
     # documentation.
-    packages_dirs = [joinpath(dir, p["path"]) for (_, p) in packages if !endswith(p["name"], "_jll")]
+    return [joinpath(registry, p["path"]) for (_, p) in packages if !endswith(p["name"], "_jll")]
 end
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,6 +17,8 @@ using AnalyzeRegistry: parse_project
     @test !measurements.buildkite
     # Test results of a couple of packages.  Same caveat as above
     packages = [joinpath(general, p...) for p in (("C", "Cuba"), ("P", "PolynomialRoots"))]
+    @test Set(packages) == Set(find_packages("Cuba", "PolynomialRoots")) == Set(find_packages(["Cuba", "PolynomialRoots"]))
+    @test packages ⊆ find_packages()
     results = analyze_from_registry(packages)
     cuba, polyroots = results
     @test length(filter(p -> p.reachable, results)) == 2


### PR DESCRIPTION
This PR changes the registry to be a keyword argument, and allows passing a list or varargs package names as strings to look up from the registry. I found it just makes it a bit less tedious than lots of `joinpath(general_registry(), "F", "Flux")` stuff. (I had a non-breaking version of this in #11 but I pulled it out here since it's entirely separate).


```julia
julia> pkgs = find_packages("AbstractPlotting", "GLMakie", "CairoMakie")
3-element Vector{String}:
 "/Users/eh540/.julia/registries/General/A/AbstractPlotting"
 "/Users/eh540/.julia/registries/General/G/GLMakie"
 "/Users/eh540/.julia/registries/General/C/CairoMakie"

julia> results = analyze_from_registry!(root, pkgs) #...
```

(This is a breaking change!).