### PR TITLE
add serialization capability

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Mosè Giordano <mose@gnu.org>"]
 version = "0.1.0"
 
 [deps]
+Arrow = "69666777-d1a9-59fb-9406-91d4454c9d45"
 BangBang = "198e06fe-97b7-11e9-32a5-e1d131e6ad66"
 FLoops = "cc61a311-1640-44b5-9fba-1b764f453329"
 JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
@@ -15,6 +16,7 @@ Tokei_jll = "3ac119c9-1236-5556-b556-adc8150b0244"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
+Arrow = "1.2.4"
 BangBang = "0.3.29"
 FLoops = "0.1.6"
 JSON3 = "1.5.1"

--- a/README.md
+++ b/README.md
@@ -83,11 +83,18 @@ end
 
 To run the analysis for multiple packages you can either use broadcasting
 ```julia
-analyze_from_registry.(package_paths_in_registry)
+results = analyze_from_registry.(package_paths_in_registry)
 ```
 or use the method `analyze_from_registry(package_paths_in_registry::AbstractVector{<:AbstractString})` which
 leaverages [`FLoops.jl`](https://github.com/JuliaFolds/FLoops.jl) to run the
-analysis with multiple threads.
+analysis with multiple threads. These results can be saved to disk via
+```julia
+AnalyzeRegistry.save("results.arrow", results)
+```
+and loaded back by
+```julia
+results_2 = AnalyzeRegistry.load("results.arrow")
+```
 
 You can use the function `find_packages` to find all packages in a given
 registry:

--- a/src/AnalyzeRegistry.jl
+++ b/src/AnalyzeRegistry.jl
@@ -80,8 +80,6 @@ julia> AnalyzeRegistry.save("bb_flux.arrow", results)
 
 julia> roundtripped_results = AnalyzeRegistry.load("bb_flux.arrow");
 
-julia> roundtripped_results = AnalyzeRegistry.load("bb_flux.arrow");
-
 julia> roundtripped_results[1]
 Package BinaryBuilder:
   * repo: https://github.com/JuliaPackaging/BinaryBuilder.jl.git
@@ -106,16 +104,12 @@ function save(path, pkgs::AbstractVector{Package})
 end
 
 """
-    load(path; materialize=false)
+    load(path)
 
-Given a `path` to a table saved by [`save`](@ref), returns an `AbstractVector{Package}`
-of those results. Set `materialize=true` to obtain a `Vector{Package}` instead of a lazy
-Arrow.jl view into a byte-buffer or Mmap'd file. See [`save`](@ref) for an example.
+Given a `path` to a table saved by [`save`](@ref), returns an `Vector{Package}`
+of those results. See [`save`](@ref) for an example.
 """
-function load(path; materialize=false)
-    pkgs = Arrow.Table(path).packages
-    return materialize ? copy(pkgs) : pkgs
-end
+load(path) = copy(Arrow.Table(path).packages)
 
 
 # define `isequal`, `==`, and `hash` just in terms of the fields

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -114,12 +114,9 @@ end
 
         AnalyzeRegistry.save(path, results)
 
-        roundtripped_results_1 = AnalyzeRegistry.load(path)
-        @test roundtripped_results_1 isa AbstractVector{AnalyzeRegistry.Package}
-        
-        roundtripped_results_2 = AnalyzeRegistry.load(path; materialize=true)
-        @test roundtripped_results_2 isa Vector{AnalyzeRegistry.Package}
+        roundtripped_results = AnalyzeRegistry.load(path)
+        @test roundtripped_results isa Vector{AnalyzeRegistry.Package}
 
-        @test results == roundtripped_results_1 == roundtripped_results_2
+        @test results == roundtripped_results
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -106,3 +106,20 @@ end
     @test occursin("* uuid: e713c705-17e4-4cec-abe0-95bf5bf3e10c", str)
     @test occursin("* OSI approved: true", str)
 end
+
+@testset "`load` and `save`" begin
+    mktempdir() do dir
+        path = joinpath(dir, "test.arrow")
+        results = analyze_from_registry(find_packages("BinaryBuilder", "Flux"))
+
+        AnalyzeRegistry.save(path, results)
+
+        roundtripped_results_1 = AnalyzeRegistry.load(path)
+        @test roundtripped_results_1 isa AbstractVector{AnalyzeRegistry.Package}
+        
+        roundtripped_results_2 = AnalyzeRegistry.load(path; materialize=true)
+        @test roundtripped_results_2 isa Vector{AnalyzeRegistry.Package}
+
+        @test results == roundtripped_results_1 == roundtripped_results_2
+    end
+end


### PR DESCRIPTION
Ok, last one I have for now 😅. Thought it would be helpful to save out the results in a more robust way than `Serialization.serialize` (which can break on new minor versions of Julia or even by the presence/removal of anonymous functions in the session!).

With this, if you have old results and don't remember which version they are from and we've changed the fields of Package in the meantime, you should be able to at least get the results back as a NamedTuple by loading it in with plain Arrow.jl (without doing `registertype!` / loading AnalyzeRegistry), and if we haven't changed the fields, you get real Package's back by `load` (which uses that we call `register_type!` in the `__init__`).