### PR TITLE
Fix for subdirs that doesn't exist at the git repo HEAD

### DIFF
--- a/src/AnalyzeRegistry.jl
+++ b/src/AnalyzeRegistry.jl
@@ -355,12 +355,17 @@ function analyze(dir::AbstractString; repo = "", reachable=true, subdir="")
         github_actions = false
     end
     license_files = find_licenses(dir)
-    if !isempty(subdir)
-        # Look for licenses at top-level and in the subdirectory
-        subdir_licenses_files = [(; license_filename = joinpath(subdir, row.license_filename), row.licenses_found, row.license_file_percent_covered) for row in find_licenses(joinpath(dir, subdir))]
-        license_files = [subdir_licenses_files; license_files]
+    if isdir(pkgdir)
+        if !isempty(subdir)
+            # Look for licenses at top-level and in the subdirectory
+            subdir_licenses_files = [(; license_filename = joinpath(subdir, row.license_filename), row.licenses_found, row.license_file_percent_covered) for row in find_licenses(pkgdir)]
+            license_files = [subdir_licenses_files; license_files]
+        end
+        lines_of_code = count_loc(pkgdir)
+    else
+        license_files = LicenseTableEltype[]
+        lines_of_code = LoCTableEltype[]
     end
-    lines_of_code = count_loc(pkgdir)
     Package(name, uuid, repo; subdir, reachable, docs, runtests, travis, appveyor, cirrus,
             circle, drone, buildkite, azure_pipelines, gitlab_pipeline, github_actions,
             license_files, licenses_in_project, lines_of_code)

--- a/src/AnalyzeRegistry.jl
+++ b/src/AnalyzeRegistry.jl
@@ -78,6 +78,13 @@ function Base.show(io::IO, p::Package)
     body = """
         Package $(p.name):
           * repo: $(p.repo)
+        """
+    if !isempty(p.subdir)
+        body *= """
+            * in subdirectory: $(p.subdir)
+        """
+    end
+    body *= """
           * uuid: $(p.uuid)
           * is reachable: $(p.reachable)
         """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -89,6 +89,10 @@ end
     snoop_compile_count_for_core = sum(row.code for row in snoop_compile.lines_of_code if row.language == :Julia && row.sublanguage===nothing && row.directory == "SnoopCompileCore")
     snoop_core_count = sum(row.code for row in snoop_core.lines_of_code if row.language == :Julia && row.sublanguage===nothing)
     @test snoop_core_count == snoop_compile_count_for_core
+
+    # this package doesn't exist in the repo anymore; let's ensure it doesn't throw
+    snoop_compile_analysis = analyze_from_registry(find_package("SnoopCompileAnalysis"))
+    @test isempty(snoop_compile_analysis.lines_of_code)
 end
 
 @testset "`parse_project`" begin


### PR DESCRIPTION
This makes some minimal changes to close #28. We just check that the subdir exists for before looking for licenses / code in it. I also added the `subdir` to the `show` method; I think this is good either way since it's interesting to see it's a subdir package, but is particularly important when we can't parse the Project.toml so we don't have a name, and the repo alone doesn't identify the package, ref https://github.com/giordano/AnalyzeRegistry.jl/issues/28#issuecomment-782979547.

```julia
julia> analyze_from_registry!(root, find_package("SnoopCompileAnalysis"))
Package Invalid Project.toml:
  * repo: https://github.com/timholy/SnoopCompile.jl.git
    * in subdirectory: SnoopCompileAnalysis
  * uuid: 00000000-0000-0000-0000-000000000000
  * is reachable: true
  * no license found
  * has documentation: false
  * has tests: false
  * has continuous integration: true
    * GitHub Actions
```

I think a simple fix like this is OK; as I see it, AnalyzeRegistry has two use cases: analyzing a whole registry, in which case a couple unreachable-at-HEAD packages is somewhat expected and it's not that important to go out of our way to find their code, and for analyzing a particular package, in which case the code probably exists or else you wouldn't be looking at it. 