### PR TITLE
RFC `healthcheck`

### DIFF
--- a/src/AnalyzeRegistry.jl
+++ b/src/AnalyzeRegistry.jl
@@ -12,6 +12,7 @@ using Tokei_jll # count lines of code
 
 export general_registry, find_package, find_packages
 export analyze, analyze_from_registry, analyze_from_registry!
+export healthcheck
 
 include("count_loc.jl")
 const LicenseTableEltype=@NamedTuple{license_filename::String, licenses_found::Vector{String}, license_file_percent_covered::Float64}
@@ -106,19 +107,10 @@ function Base.show(io::IO, p::Package)
               * has documentation: $(p.docs)
               * has tests: $(p.runtests)
             """
-        ci_services = (p.github_actions => "GitHub Actions",
-                       p.travis => "Travis",
-                       p.appveyor => "AppVeyor",
-                       p.cirrus => "Cirrus",
-                       p.circle => "Circle",
-                       p.drone => "Drone CI",
-                       p.buildkite => "Buildkite",
-                       p.azure_pipelines => "Azure Pipelines",
-                       p.gitlab_pipeline => "GitLab Pipeline",
-                       )
-        if any(first.(ci_services))
+        ci = ci_services(p)
+        if any(first.(ci))
             body *= "  * has continuous integration: true\n"
-            for (k, v) in ci_services
+            for (k, v) in ci
                 if k
                     body *= "    * $(v)\n"
                 end
@@ -128,6 +120,61 @@ function Base.show(io::IO, p::Package)
         end
     end
     print(io, strip(body))
+end
+
+function ci_services(p)
+    return (p.github_actions => "GitHub Actions",
+            p.travis => "Travis",
+            p.appveyor => "AppVeyor",
+            p.cirrus => "Cirrus",
+            p.circle => "Circle",
+            p.drone => "Drone CI",
+            p.buildkite => "Buildkite",
+            p.azure_pipelines => "Azure Pipelines",
+            p.gitlab_pipeline => "GitLab Pipeline")
+end
+
+emojify(b::Bool) = b ? "☑" : "◻"
+
+function print_check(io, check, name, parens)
+    print(io, emojify(check), " ", name)
+    if check && !isempty(parens)
+        println(io, " (", parens, ")")
+    else
+        println(io)
+    end
+end
+
+function healthcheck(p::Package)
+    body = sprint() do io
+        jl_test = count_loc(p.lines_of_code, "test", :Julia)
+        jl_src = count_loc(p.lines_of_code, "src", :Julia)
+        jl_doc = count_docs(p.lines_of_code)
+        println(io, p.name, ".jl")
+        print_check(io, jl_src > 5, "Has code", "$(jl_src) lines")
+        print_check(io, p.docs, "Has docs", "$(jl_doc) lines")
+        print_check(io, p.runtests && jl_test > 5, "Has tests", "$(jl_test) lines")
+        licenses = String[]
+        append!(licenses, p.licenses_in_project)
+        for lic in p.license_files
+            append!(licenses, lic.licenses_found)
+        end
+        print_check(io, !isempty(licenses) && any(is_osi_approved, licenses), "Has license(s)", "")
+        for lic in licenses
+            check = is_osi_approved(lic)
+            print(io, "    $lic (")
+            if check
+                print(io, "✔ OSI-approved)")
+            else
+                print(io, "⨉ Not OSI-approved)")
+            end
+            println(io)
+            # print_check(io, check, "OSI: $lic", "")
+        end
+        services = [v for (k,v) in ci_services(p) if k]
+        print_check(io, !isempty(services), "Has CI", join(services, ", "))
+    end
+    print(body)
 end
 
 """

--- a/src/count_loc.jl
+++ b/src/count_loc.jl
@@ -1,4 +1,4 @@
-function count_loc(dir)
+function count_loc(dir::AbstractString)
     # we `cd` so that we get relative paths in the `tokei` output.
     # This makes it easy to process later, since we have uniform filepaths
     json = cd(dir) do
@@ -54,4 +54,7 @@ function loc_update!(d, key, new)
     d[key] = (; files = prev.files + 1, code = prev.code + new.code, comments = prev.comments + new.comments, blanks = prev.blanks + new.blanks )
 end
 
-count_julia_loc(table, dir) = sum(row.code for row in table if row.directory == dir && row.language == :Julia; init=0)
+count_julia_loc(table, dir) = count_loc(table, dir, :Julia)
+count_loc(table, dir::AbstractString, language::Symbol) = sum(row.code for row in table if row.directory == dir && row.language == language; init=0)
+count_loc(table, dir::AbstractString) = sum(row.code for row in table if row.directory == dir; init=0)
+count_docs(table) = sum(row.code + row.comments for row in table if row.directory in ("docs", "doc"); init=0)


### PR DESCRIPTION
This adds a `healthcheck` function which is basically an alternate `show` method:
```julia
julia> healthcheck(analyze_from_registry(find_package("DataFrames")))
DataFrames.jl
☑ Has code (16163 lines)
☑ Has docs (3431 lines)
☑ Has tests (16296 lines)
☑ Has license(s)
    MIT (✔ OSI-approved)
☑ Has CI (GitHub Actions)

julia> healthcheck(analyze_from_registry(find_package("CommonMark")))
CommonMark.jl
☑ Has code (3943 lines)
◻ Has docs
☑ Has tests (1215 lines)
☑ Has license(s)
    MIT (✔ OSI-approved)
    BSD-2-Clause (✔ OSI-approved)
    MIT (✔ OSI-approved)
    MIT (✔ OSI-approved)
    CC-BY-SA-4.0 (⨉ Not OSI-approved)
☑ Has CI (GitHub Actions)
```

The idea is it could be used by a package author / maintainer themselves to quickly get a look at the status of their package and/or check off some boxes 🙂. It could also be autocommented in General PRs for package authors to get a sense of the "health" of the package/version they are releasing, and give a nudge towards good practices (and provide more info for passers-by).

Here I used empty boxes instead of Xs to try to be more encouraging.

Opening as draft for feedback; I feel like it could probably use some more tweaking still.