### PR TITLE
Close STDIN to prevent git from prompting for username/password

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -107,9 +107,12 @@ end
 end
 
 @testset "`analyze_path!`" begin
-    # we check the error path here; the success path is covered by other tests
-    result = AnalyzeRegistry.analyze_path!(mktempdir(), "https://github.com/giordano/DOES_NOT_EXIST!!!.jl")
+    # we check the error path here; the success path is covered by other tests.
+    # This also makes sure trying to clone the repo doesn't prompt for
+    # username/password
+    result = AnalyzeRegistry.analyze_path!(mktempdir(), "https://github.com/giordano/DOES_NOT_EXIST.jl")
     @test result isa AnalyzeRegistry.Package
+    @test !result.reachable
     @test isempty(result.name)
 end
 


### PR DESCRIPTION
Also, make the test with the non-existing repo more robust: GitHub doesn't allow
`!` in repo names, so trying to clone `DOES_NOT_EXIST!!!.jl` would fail
immediately anyway.  Instead we want to test that trying to clone a repo with a
valid name doesn't prompt for username/password.