### PR TITLE
Use `Threads.foreach` for load-balanced threading

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,24 +4,18 @@ authors = ["Mosè Giordano <mose@gnu.org>"]
 version = "0.1.0"
 
 [deps]
-BangBang = "198e06fe-97b7-11e9-32a5-e1d131e6ad66"
-FLoops = "cc61a311-1640-44b5-9fba-1b764f453329"
 GitHub = "bc5e4493-9b4d-5f90-b8aa-2b2bcaad7a26"
 JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
 LicenseCheck = "726dbf0d-6eb6-41af-b36c-cd770e0f00cc"
-MicroCollections = "128add7d-3638-4c79-886c-908ea0c25c34"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 Tokei_jll = "3ac119c9-1236-5556-b556-adc8150b0244"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
-BangBang = "0.3.29"
-FLoops = "0.1.6"
 GitHub = "5.4"
 JSON3 = "1.5.1"
 LicenseCheck = "0.2"
-MicroCollections = "0.1.0"
 julia = "1.6"
 
 [extras]

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -138,8 +138,7 @@ To run the analysis for multiple packages you can either use broadcasting
 analyze.(registry_entries)
 ```
 or use the method `analyze(registry_entries::AbstractVector{<:RegistryEntry})` which
-leaverages [`FLoops.jl`](https://github.com/JuliaFolds/FLoops.jl) to run the
-analysis with multiple threads.
+runs the analysis with multiple threads.
 
 You can use the function [`find_packages`](@ref) to find all packages in a given
 registry:


### PR DESCRIPTION
To drop the FLoops dependency. That + GitCommand 3.0 would bring us down to a small set of light dependencies.